### PR TITLE
fix: bugfixes in connectorland peering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu
 RUN apt-get update && apt-get install -yq \
+    build-essential \
     default-jre \
     vim \
+    wget \
     zookeeperd
-RUN apt-get install -yq wget
 RUN wget "http://www-eu.apache.org/dist/kafka/0.11.0.0/kafka_2.11-0.11.0.0.tgz" -O kafka.tgz
 RUN tar -xzvf kafka.tgz --strip 1
 # Replace shell with bash so we can source files
@@ -22,9 +23,14 @@ RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.s
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
-ADD . .
+WORKDIR /app
+
+ADD package.json /app
 RUN source $NVM_DIR/nvm.sh && npm install
+
+# postponed this step, for more efficient rebuild while debugging the repo contents,
+ADD . /app
+
 ENV PORT 3010
 EXPOSE 3010
-RUN echo 127.0.0.1\ moby >> /etc/hosts
 CMD sh ./scripts/start.sh

--- a/scripts/connectorland.js
+++ b/scripts/connectorland.js
@@ -51,7 +51,13 @@ function run(ilpDomain) {
     const token = base64url(crypto.randomBytes(32))
     const ilpSecret = 'ilp_secret:'+base64url(Buffer.from('https://' + CONNECTORLAND_LEDGER_PREFIX + ':' + token + '@' + ilpDomain + '/rpc', 'ascii'))
 
-    peers[CONNECTORLAND_LEDGER_PREFIX] = { uri: CONNECTORLAND_RPC_URI, token }
+    peers[CONNECTORLAND_LEDGER_PREFIX] = {
+      uri: CONNECTORLAND_RPC_URI,
+      token,
+      broadcast: true,
+      currencyCode: 'USD',
+      currencyScale: 9
+    }
     writePeers(peers)
     writeIlpSecret(ilpSecret)
     console.log('Wrote ' + CONNECTORLAND_ILP_SECRET_FILENAME, ilpSecret)

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 source $NVM_DIR/nvm.sh
-node scripts/connectorland.js $ILP_DOMAIN
-curl "https://connector.land/stats?test=`cat config/connectorland-ilp-secret.txt`"
+echo SETTING UP CONNECTORLAND PEERING $API_HOSTNAME
+node scripts/connectorland.js $API_HOSTNAME
+wget "https://connector.land/test?peer=`cat config/connectorland-ilp-secret.txt`"
 /etc/init.d/zookeeper start
 sleep 10
 (/bin/kafka-server-start.sh /config/server.properties &)


### PR DESCRIPTION
* more efficient way of building dockerfile while debugging the repo
* fix node-gyp dependency 
* fix pre-twilight env var for hostname
* use wget instead of not-installed curl